### PR TITLE
fix: delete db active_deals table after test

### DIFF
--- a/backend/test/deal-observer.test.js
+++ b/backend/test/deal-observer.test.js
@@ -14,6 +14,7 @@ describe('deal-observer-backend', () => {
   })
 
   after(async () => {
+    await pgPool.query('DELETE FROM active_deals')
     await pgPool.end()
   })
 


### PR DESCRIPTION
We need to delete the table `active_deals` after all the tests are done to avoid the tests leaving the database altered after the tests are run. 