### PR TITLE
disable `CODEOWNERS` on pkg files, to unbreak automerge

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 * @bajtos @NikolasHaimerl
+*/package.json
+package-lock.json


### PR DESCRIPTION
https://github.com/orgs/community/discussions/23064