### PR TITLE
fix: account for archive limit

### DIFF
--- a/backend/bin/deal-observer-backend.js
+++ b/backend/bin/deal-observer-backend.js
@@ -32,13 +32,13 @@ const dealObserverLoop = async (makeRpcRequest, pgPool) => {
       const currentMaxPastEpoch = currentChainHead.Height - maxPastEpochs
       // If the storage is empty we start 2000 blocks into the past as that is the furthest we can go with the public glif rpc endpoints.
       const lastInsertedDeal = await fetchDealWithHighestActivatedEpoch(pgPool)
-      const lastEpochStored = lastInsertedDeal ? lastInsertedDeal.activated_at_epoch : currentMaxPastEpoch
-      let startEpoch = lastEpochStored + 1
+      let startEpoch = currentMaxPastEpoch
       // The free tier of the glif rpc endpoint only allows us to go back 2000 blocks.
       // We should respect the limit and not go further back than that.
-      if (startEpoch < currentMaxPastEpoch) {
-        startEpoch = currentMaxPastEpoch
+      if (lastInsertedDeal && lastInsertedDeal.activated_at_epoch + 1 >= currentMaxPastEpoch) {
+        startEpoch = lastInsertedDeal.activated_at_epoch + 1
       }
+
       for (let epoch = startEpoch; epoch <= currentFinalizedChainHead; epoch++) {
         await observeBuiltinActorEvents(epoch, pgPool, makeRpcRequest)
       }


### PR DESCRIPTION
This PR proposes the following changes:

1. Account for the archive limit of the GLIF RPC API

The [glif api](https://api.node.glif.io/) has the following limits:

> Please note that if you make requests without authorization, rate-limiting of 100 requests per minute will apply, and will only guarantee access to the latest 2000 blocks.

We need to account for that. We should not try to fetch blocks which are further out in the past than 2000 blocks. 