### PR TITLE
fix: remove max past epochs

### DIFF
--- a/backend/bin/deal-observer-backend.js
+++ b/backend/bin/deal-observer-backend.js
@@ -15,8 +15,6 @@ const LOOP_INTERVAL = 10 * 1000
 // Filecoin will need some epochs to reach finality.
 // We do not want to fetch deals that are newer than the current chain head - 940 epochs.
 const finalityEpochs = 940
-// The free tier of the Glif RPC endpoint allows for 100 requests per minute.
-const maximumRequestsPerMinute = 100
 const pgPool = await createPgPool()
 
 const LOOP_NAME = 'Built-in actor events'
@@ -30,9 +28,7 @@ const dealObserverLoop = async (makeRpcRequest, pgPool) => {
       const currentFinalizedChainHead = currentChainHead.Height - finalityEpochs
       // If the storage is empty we start 2000 blocks into the past as that is the furthest we can go with the public glif rpc endpoints.
       const lastInsertedDeal = await fetchDealWithHighestActivatedEpoch(pgPool)
-      // If there are no deals in the database we start from the current chain head - and use the maximum number of requests we can perform per minute as a lower bound.
-      // This is to avoid hitting the rate limit of the glif rpc endpoint and introduces more recilience to database gaps.
-      const lastEpochStored = lastInsertedDeal ? lastInsertedDeal.activated_at_epoch : currentFinalizedChainHead - maximumRequestsPerMinute
+      const lastEpochStored = lastInsertedDeal ? lastInsertedDeal.activated_at_epoch : currentFinalizedChainHead - 1
       for (let epoch = lastEpochStored + 1; epoch <= currentFinalizedChainHead; epoch++) {
         await observeBuiltinActorEvents(epoch, pgPool, makeRpcRequest)
       }

--- a/backend/bin/deal-observer-backend.js
+++ b/backend/bin/deal-observer-backend.js
@@ -6,7 +6,6 @@ import '../lib/instrument.js'
 import { createInflux } from '../lib/telemetry.js'
 import { getChainHead, rpcRequest } from '../lib/rpc-service/service.js'
 import { fetchDealWithHighestActivatedEpoch, observeBuiltinActorEvents } from '../lib/deal-observer.js'
-import assert from 'node:assert'
 
 const { INFLUXDB_TOKEN } = process.env
 if (!INFLUXDB_TOKEN) {
@@ -16,8 +15,6 @@ const LOOP_INTERVAL = 10 * 1000
 // Filecoin will need some epochs to reach finality.
 // We do not want to fetch deals that are newer than the current chain head - 940 epochs.
 const finalityEpochs = 940
-const maxPastEpochs = 1999
-assert(finalityEpochs <= maxPastEpochs)
 const pgPool = await createPgPool()
 
 const LOOP_NAME = 'Built-in actor events'
@@ -31,7 +28,7 @@ const dealObserverLoop = async (makeRpcRequest, pgPool) => {
       const currentFinalizedChainHead = currentChainHead.Height - finalityEpochs
       // If the storage is empty we start 2000 blocks into the past as that is the furthest we can go with the public glif rpc endpoints.
       const lastInsertedDeal = await fetchDealWithHighestActivatedEpoch(pgPool)
-      const lastEpochStored = lastInsertedDeal ? lastInsertedDeal.activated_at_epoch : currentChainHead.Height - maxPastEpochs
+      const lastEpochStored = lastInsertedDeal ? lastInsertedDeal.activated_at_epoch : currentFinalizedChainHead - 1
       for (let epoch = lastEpochStored + 1; epoch <= currentFinalizedChainHead; epoch++) {
         await observeBuiltinActorEvents(epoch, pgPool, makeRpcRequest)
       }


### PR DESCRIPTION
The free tier of GLIF RPC api allows for a maximum of 100 requests per minute. If we start with 2000 blocks in the pasts we will get rate limiting errors in the beginning of the sync as we will make more calls than 100 per minute to catch up with the current head. 
To avoid this we can remove the max past epoch variable. 